### PR TITLE
Disable rich text in notepad widget

### DIFF
--- a/src/view/padwidget.cpp
+++ b/src/view/padwidget.cpp
@@ -165,6 +165,7 @@ public:
 
         mEdit->setFont(fixedFont);
         mEdit->setMinimumWidth(QFontMetrics(fixedFont).averageCharWidth() * 70);
+        mEdit->setAcceptRichText(false);
 
         if (KeyCache::instance()->pgpOnly()) {
             mSigEncWidget->setProtocol(GpgME::OpenPGP);


### PR DESCRIPTION
When copied from a rich text source, Kleopatra allows rich text to be pasted into its notepad widget, which results in errors decrypting/verifying messages. This commit restricts the QTextEdit widget in padwidget.cpp to plain text only.

I have tested this change and it works on my machine; still, there may be a better solution to this, like using QPlainTextEdit instead for example.